### PR TITLE
필수 패키지, Path alias 설정

### DIFF
--- a/library/utils/date/date.ts
+++ b/library/utils/date/date.ts
@@ -1,0 +1,4 @@
+import * as dateFns from 'date-fns';
+
+export const now = (date?: Date) => (date ? new Date(date) : new Date());
+export const dateToISO = (date: Date) => dateFns.formatISO(date);

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "ts-jest": "^27.0.3",
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
-    "tsconfig-paths": "^3.10.1",
+    "tsconfig-paths": "^3.14.1",
     "typescript": "^4.3.5"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@nestjs/common": "^8.0.0",
     "@nestjs/core": "^8.0.0",
     "@nestjs/platform-express": "^8.0.0",
+    "date-fns": "^2.28.0",
     "lodash": "^4.17.21",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@nestjs/common": "^8.0.0",
     "@nestjs/core": "^8.0.0",
     "@nestjs/platform-express": "^8.0.0",
+    "lodash": "^4.17.21",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
     "rxjs": "^7.2.0"

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get } from '@nestjs/common';
-import { AppService } from './app.service';
+import { AppService } from '@api/app.service';
 
 @Controller()
 export class AppController {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
-import { AppController } from './app.controller';
-import { AppService } from './app.service';
+import { AppService } from '@api/app.service';
+import { AppController } from '@api/app.controller';
 
 @Module({
   imports: [],

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { NestFactory } from '@nestjs/core';
-import { AppModule } from './app.module';
+import { AppModule } from '@api/app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,18 @@
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "noUnusedParameters": true,
-		"noUncheckedIndexedAccess": true
+		"noUncheckedIndexedAccess": true,
+    // NOTE: @api: 비즈니스 로직, @app: 기타 라이브러리 파일, 경로가 깊은 순서대로 정렬
+    "paths": {
+      "@app/utils/*":[
+        "./library/utils/*"
+      ],
+      "@app/library/*":[
+        "./library/*"
+      ],
+      "@api/*":[
+        "./src/*"
+      ],
+    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1877,6 +1877,11 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+date-fns@^2.28.0:
+  version "2.28.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.28.0.tgz#9570d656f5fc13143e50c975a3b6bbeb46cd08b2"
+  integrity sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==
+
 debug@2.6.9, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4976,7 +4976,7 @@ tsconfig-paths@3.14.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tsconfig-paths@^3.10.1, tsconfig-paths@^3.12.0, tsconfig-paths@^3.9.0:
+tsconfig-paths@^3.12.0, tsconfig-paths@^3.14.1, tsconfig-paths@^3.9.0:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz#ba0734599e8ea36c862798e920bcf163277b137a"
   integrity sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==


### PR DESCRIPTION
# 구현 개요
- 필요 필수 패키지 설치
- Path alias 설정

## 작업 사항
- lodash 추가
- date-fns 추가
- tsconfig-paths 추가

- tsconfig 경로 별칭 추가
- date-fns 유틸리티 파일 생성
- 기존 서비스 로직에 path alias 반영

## 이슈 트래커 번호
resolve #7 

# 🔥 참고사항 (필수) 🔥
1. VSC에서 경로 별칭을 우선적으로 사용하기 위해서는 해당 [이슈](https://github.com/Microsoft/vscode/issues/59815)에서 언급하는 환경설정이 필요합니다
`typescript.preferences.importModuleSpecifier": "non-relative`

2. 1번에서 수행한 설정은 가장 위에 작성된 설정을 우선적으로 사용하기때문에 이후 별칭을 추가할 때 경로가 깊은순 대로 정렬해야합니다

```
      "@app/utils/*":[
        "./library/utils/*"
      ],
      "@app/library/*":[
        "./library/*"
      ],
      "@api/*":[
        "./src/*"
      ],
```
