### PR TITLE
불필요한 스키마 삭제, 스키마 마이그레이션 작업

### DIFF
--- a/prisma/migrations/20220411143849_delete_table/migration.sql
+++ b/prisma/migrations/20220411143849_delete_table/migration.sql
@@ -1,0 +1,39 @@
+/*
+  Warnings:
+
+  - You are about to drop the `pinnedRepositories` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `pinnedRepositoryCategories` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `postsTags` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `tags` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `userblogCustomization` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE `pinnedRepositoryCategories` DROP FOREIGN KEY `FK_pinnedRepositoryCategories_categoryID_category_id`;
+
+-- DropForeignKey
+ALTER TABLE `pinnedRepositoryCategories` DROP FOREIGN KEY `FK_pinnedRepositoryCategories_pinnedRepositoriesID_pinnedReposit`;
+
+-- DropForeignKey
+ALTER TABLE `postsTags` DROP FOREIGN KEY `FK_postsTags_postsID_posts_id`;
+
+-- DropForeignKey
+ALTER TABLE `postsTags` DROP FOREIGN KEY `FK_postsTags_tagsID_tags_id`;
+
+-- DropForeignKey
+ALTER TABLE `userblogCustomization` DROP FOREIGN KEY `FK_userblogCustomization_usersID_users_id`;
+
+-- DropTable
+DROP TABLE `pinnedRepositories`;
+
+-- DropTable
+DROP TABLE `pinnedRepositoryCategories`;
+
+-- DropTable
+DROP TABLE `postsTags`;
+
+-- DropTable
+DROP TABLE `tags`;
+
+-- DropTable
+DROP TABLE `userblogCustomization`;

--- a/prisma/migrations/20220411145117_delete_users_column/migration.sql
+++ b/prisma/migrations/20220411145117_delete_users_column/migration.sql
@@ -1,0 +1,18 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `accessToken` on the `users` table. All the data in the column will be lost.
+  - You are about to drop the column `admin` on the `users` table. All the data in the column will be lost.
+  - You are about to drop the column `oAuthServiceID` on the `users` table. All the data in the column will be lost.
+  - You are about to drop the column `oAuthType` on the `users` table. All the data in the column will be lost.
+  - You are about to drop the column `password` on the `users` table. All the data in the column will be lost.
+  - You are about to drop the column `refreshToken` on the `users` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE `users` DROP COLUMN `accessToken`,
+    DROP COLUMN `admin`,
+    DROP COLUMN `oAuthServiceID`,
+    DROP COLUMN `oAuthType`,
+    DROP COLUMN `password`,
+    DROP COLUMN `refreshToken`;

--- a/prisma/migrations/20220411145851_delete_comments_reply_level/migration.sql
+++ b/prisma/migrations/20220411145851_delete_comments_reply_level/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `replyLevel` on the `comments` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE `comments` DROP COLUMN `replyLevel`;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -91,18 +91,12 @@ model posts {
 
 model users {
   id                    Int                    @id @default(autoincrement()) @db.UnsignedInt
-  oAuthType             String                 @db.VarChar(10)
-  oAuthServiceID        String                 @db.VarChar(50)
   userName              String                 @default("User") @db.VarChar(50)
   proFileImageURL       String?                @db.VarChar(300)
   mailAddress           String?                @db.VarChar(50)
-  password              String?                @db.VarChar(50)
-  accessToken           String                 @db.VarChar(255)
-  refreshToken          String?                @db.VarChar(255)
   createdAt             DateTime               @db.DateTime(0)
   updatedAt             DateTime?              @db.DateTime(0)
   deletedAt             DateTime?              @db.DateTime(0)
-  admin                 Int                    @default(0) @db.TinyInt
   comments              comments[]
   imageUpload           imageUpload[]
   postLike              postLike[]

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,7 +11,6 @@ model category {
   id                         Int                          @id @default(autoincrement()) @db.UnsignedInt
   categoryName               String                       @db.VarChar(30)
   iconURL                    String?                      @db.VarChar(300)
-  pinnedRepositoryCategories pinnedRepositoryCategories[]
   posts                      posts[]
 }
 
@@ -42,26 +41,6 @@ model imageUpload {
   users         users?   @relation(fields: [usersID], references: [id], map: "FK_imageUpload_usersID_users_id")
 
   @@index([usersID], map: "FK_imageUpload_usersID_users_id")
-}
-
-model pinnedRepositories {
-  id                         Int                          @id @default(autoincrement()) @db.UnsignedInt
-  nodeID                     String                       @db.VarChar(30)
-  processPercent             Int                          @default(0) @db.TinyInt
-  demoURL                    String?                      @db.VarChar(300)
-  position                   String?                      @db.VarChar(10)
-  pinnedRepositoryCategories pinnedRepositoryCategories[]
-}
-
-model pinnedRepositoryCategories {
-  id                   Int                @id @default(autoincrement()) @db.UnsignedInt
-  categoryID           Int                @db.UnsignedInt
-  pinnedRepositoriesID Int                @db.UnsignedInt
-  category             category           @relation(fields: [categoryID], references: [id], onDelete: Cascade, map: "FK_pinnedRepositoryCategories_categoryID_category_id")
-  pinnedRepositories   pinnedRepositories @relation(fields: [pinnedRepositoriesID], references: [id], onDelete: Cascade, map: "FK_pinnedRepositoryCategories_pinnedRepositoriesID_pinnedReposit")
-
-  @@index([categoryID], map: "FK_pinnedRepositoryCategories_categoryID_category_id")
-  @@index([pinnedRepositoriesID], map: "FK_pinnedRepositoryCategories_pinnedRepositoriesID_pinnedReposit")
 }
 
 model postLike {
@@ -104,38 +83,10 @@ model posts {
   comments        comments[]
   postLike        postLike[]
   postView        postView[]
-  postsTags       postsTags[]
 
   @@index([categoryID], map: "FK_posts_categoryID_category_id")
   @@index([likes, createdAt], map: "createdAt_likes_INDEX")
   @@index([usersID, id], map: "userID_postID_INDEX")
-}
-
-model postsTags {
-  id        BigInt   @id @default(autoincrement())
-  postsID   BigInt
-  tagsID    BigInt
-  createdAt DateTime @db.DateTime(0)
-  posts     posts    @relation(fields: [postsID], references: [id], onDelete: Cascade, map: "FK_postsTags_postsID_posts_id")
-  tags      tags     @relation(fields: [tagsID], references: [id], onDelete: Cascade, map: "FK_postsTags_tagsID_tags_id")
-
-  @@index([postsID], map: "FK_postsTags_postsID_posts_id")
-  @@index([tagsID], map: "FK_postsTags_tagsID_tags_id")
-}
-
-model tags {
-  id        BigInt      @id @default(autoincrement())
-  tagsName  String      @db.VarChar(30)
-  createdAt DateTime    @db.DateTime(0)
-  postsTags postsTags[]
-}
-
-model userblogCustomization {
-  usersID          Int     @id @db.UnsignedInt
-  blogTitle        String? @db.VarChar(20)
-  statusMessage    String? @db.VarChar(30)
-  selfIntroduction String? @db.VarChar(300)
-  users            users   @relation(fields: [usersID], references: [id], onDelete: Cascade, map: "FK_userblogCustomization_usersID_users_id")
 }
 
 model users {
@@ -156,5 +107,4 @@ model users {
   imageUpload           imageUpload[]
   postLike              postLike[]
   posts                 posts[]
-  userblogCustomization userblogCustomization?
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,7 +20,6 @@ model comments {
   postsID     BigInt
   htmlContent String    @db.VarChar(300)
   replyTo     BigInt?
-  replyLevel  Int       @default(0) @db.TinyInt
   createdAt   DateTime  @db.DateTime(0)
   updatedAt   DateTime? @db.DateTime(0)
   deletedAt   DateTime? @db.DateTime(0)


### PR DESCRIPTION
# 구현 개요

- 스키마  삭제

## 작업 사항

- postsTags 테이블 삭제
- tags 테이블 삭제
- userblogCustomization 테이블 삭제
- pinnedRepositoryCategories 테이블 삭제
- pinnedRepositories 테이블 삭제
- users 테이블 컬럼 삭제
    - oAuthType 컬럼 삭제
    - oAuthServiceID 컬럼 삭제
    - password 컬럼 삭제
    - accessToken 컬럼 삭제
    - refreshToken 컬럼 삭제
    - admin 컬럼 삭제
- comments 테이블 컬럼 삭제
  - replyLevel 컬럼 삭제  

## 이슈 트래커 번호

resolve #13 