### PR TITLE
게시글 상세조회

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,6 +24,6 @@ module.exports = {
     '@typescript-eslint/no-explicit-any': 'off',
     'import/prefer-default-export': 'off',
     'class-methods-use-this': 'off',
-    "max-classes-per-file": ["error", 2]
+    "max-classes-per-file": 'off'
   },
 };

--- a/library/prisma/prisma.service.ts
+++ b/library/prisma/prisma.service.ts
@@ -6,6 +6,17 @@ export class PrismaService
   extends PrismaClient
   implements OnModuleInit, OnModuleDestroy
 {
+  constructor() {
+    super({
+      log: [
+        { emit: 'stdout', level: 'query' },
+        { emit: 'stdout', level: 'info' },
+        { emit: 'stdout', level: 'warn' },
+        { emit: 'stdout', level: 'error' },
+      ],
+    });
+  }
+
   async onModuleInit() {
     await this.$connect();
   }

--- a/library/prisma/type/prisma.type.ts
+++ b/library/prisma/type/prisma.type.ts
@@ -1,0 +1,10 @@
+import { Prisma, PrismaClient } from '@prisma/client';
+
+export type PrismaConnection = Omit<
+  PrismaClient<
+    Prisma.PrismaClientOptions,
+    never,
+    Prisma.RejectOnNotFound | Prisma.RejectPerOperation | undefined
+  >,
+  '$connect' | '$disconnect' | '$on' | '$transaction' | '$use'
+>;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,5 +1,6 @@
 generator client {
-  provider = "prisma-client-js"
+  provider        = "prisma-client-js"
+  previewFeatures = ["interactiveTransactions"]
 }
 
 datasource db {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -24,7 +24,14 @@ import { PostsModule } from './posts/posts.module';
   controllers: [],
   providers: [
     { provide: APP_INTERCEPTOR, useClass: ClassSerializerInterceptor },
-    { provide: APP_PIPE, useClass: ValidationPipe },
+    {
+      provide: APP_PIPE,
+      useValue: new ValidationPipe({
+        transform: true,
+        whitelist: true,
+        forbidUnknownValues: true,
+      }),
+    },
     { provide: APP_FILTER, useClass: AllExceptionsFilter },
   ],
 })

--- a/src/posts/dto/create-post.dto.ts
+++ b/src/posts/dto/create-post.dto.ts
@@ -3,6 +3,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
 import {
   IsBoolean,
+  IsNotEmpty,
   IsNumber,
   IsOptional,
   IsString,
@@ -11,28 +12,33 @@ import {
 
 export class CreatePostRequestBodyDto {
   @IsNumber()
+  @IsNotEmpty()
   categoryId: posts['categoryID'];
 
   @IsString()
+  @IsNotEmpty()
   @MaxLength(50)
   title: posts['title'];
 
   @IsOptional()
   @IsString()
   @MaxLength(50)
-  @ApiProperty({ nullable: true })
-  subTitle: NonNullable<posts['subTitle']>;
+  @ApiProperty({ type: String, nullable: true })
+  subTitle: posts['subTitle'];
 
   @IsOptional()
   @IsString()
   @MaxLength(300)
-  @ApiProperty({ nullable: true })
-  thumbnailUrl: NonNullable<posts['thumbNailURL']>;
+  @ApiProperty({ type: String, nullable: true })
+  thumbnailUrl: posts['thumbNailURL'];
 
   @IsString()
-  markdownContent: NonNullable<posts['markDownContent']>;
+  @IsNotEmpty()
+  @ApiProperty({ type: String, nullable: true })
+  markdownContent: posts['markDownContent'];
 
   @Transform(({ value }) => value === 'true')
   @IsBoolean()
+  @IsNotEmpty()
   isPrivate: boolean;
 }

--- a/src/posts/dto/get-post-detail.dto.ts
+++ b/src/posts/dto/get-post-detail.dto.ts
@@ -1,0 +1,60 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { category, posts, users } from '@prisma/client';
+import { Transform } from 'class-transformer';
+import { IsNotEmpty } from 'class-validator';
+
+export class GetPostDetailRequestQueryDto {
+  @Transform(({ value }) => BigInt(value))
+  @IsNotEmpty()
+  @ApiProperty({ type: String })
+  postId: bigint;
+}
+
+export class GetPostDetailResponseDto {
+  @Transform(({ value }) => String(value))
+  @ApiProperty({ type: 'string' })
+  id: posts['id'];
+
+  title: posts['title'];
+
+  @ApiProperty({ type: String, nullable: true })
+  subTitle: posts['subTitle'];
+
+  @ApiProperty({ type: String, nullable: true })
+  thumbnailUrl: posts['thumbNailURL'];
+
+  view: posts['viewCounts'];
+
+  like: posts['likes'];
+
+  @ApiProperty({ type: String })
+  content: posts['markDownContent'];
+
+  createdAt: posts['createdAt'];
+
+  @ApiProperty({ type: Date, nullable: true })
+  updatedAt: posts['updatedAt'];
+
+  user: PostDetailUserInfoItem;
+
+  category: PostDetailCategoryItem;
+
+  constructor(required: Required<GetPostDetailResponseDto>) {
+    Object.assign(this, required);
+  }
+}
+
+class PostDetailUserInfoItem {
+  userId: users['id'];
+
+  username: users['userName'];
+
+  @ApiProperty({ type: String, nullable: true })
+  avatar: users['proFileImageURL'];
+}
+
+class PostDetailCategoryItem {
+  categoryId: category['id'];
+
+  name: category['categoryName'];
+}

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -1,12 +1,22 @@
-import { Body, Controller, UnauthorizedException } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Ip,
+  Query,
+  UnauthorizedException,
+} from '@nestjs/common';
 
 import { PostsService } from '@api/posts/posts.service';
-import { CreatePost } from '@api/posts/posts.decorator';
+import { CreatePost, GetPostDetail } from '@api/posts/posts.decorator';
 import { JwtUserId } from '@app/utils/decorators/jwt-user-Id.decorator';
 
 import { CreatePostRequestBodyDto } from '@api/posts/dto/create-post.dto';
 import { decodeAccessTokenFail } from '@api/users/auth/errors/users-auth.error';
 import { TokenPayload } from '@app/utils/token/types/token.type';
+import {
+  GetPostDetailRequestQueryDto,
+  GetPostDetailResponseDto,
+} from '@api/posts/dto/get-post-detail.dto';
 
 @Controller('posts')
 export class PostsController {
@@ -20,5 +30,38 @@ export class PostsController {
     if (!userId) throw new UnauthorizedException(decodeAccessTokenFail);
     await this.postsService.createPost({ userId, ...createPostRequestBodyDto });
     return null;
+  }
+
+  @GetPostDetail()
+  async getPostDetail(
+    @Query() { postId }: GetPostDetailRequestQueryDto,
+    @JwtUserId() { userId }: TokenPayload,
+    @Ip() userIp: string,
+  ) {
+    const result = await this.postsService.getPostDetail(
+      postId,
+      userId,
+      userIp,
+    );
+    return new GetPostDetailResponseDto({
+      id: result.id,
+      title: result.title,
+      subTitle: result.subTitle,
+      thumbnailUrl: result.thumbNailURL,
+      view: result.viewCounts,
+      like: result.likes,
+      content: result.markDownContent,
+      createdAt: result.createdAt,
+      updatedAt: result.updatedAt,
+      user: {
+        userId: result.users.id,
+        username: result.users.userName,
+        avatar: result.users.proFileImageURL,
+      },
+      category: {
+        categoryId: result.category.id,
+        name: result.category.categoryName,
+      },
+    });
   }
 }

--- a/src/posts/posts.decorator.ts
+++ b/src/posts/posts.decorator.ts
@@ -2,6 +2,7 @@ import { applyDecorators, Get, Post } from '@nestjs/common';
 import { ApiOkResponse } from '@nestjs/swagger';
 
 import { JwtAccessTokenGuard } from '@app/utils/guards/auth/jwt-access-token.guard';
+
 import { GetPostDetailResponseDto } from '@api/posts/dto/get-post-detail.dto';
 
 export const CreatePost = () =>

--- a/src/posts/posts.decorator.ts
+++ b/src/posts/posts.decorator.ts
@@ -1,11 +1,22 @@
-import { applyDecorators, Post } from '@nestjs/common';
+import { applyDecorators, Get, Post } from '@nestjs/common';
 import { ApiOkResponse } from '@nestjs/swagger';
 
 import { JwtAccessTokenGuard } from '@app/utils/guards/auth/jwt-access-token.guard';
+import { GetPostDetailResponseDto } from '@api/posts/dto/get-post-detail.dto';
 
 export const CreatePost = () =>
   applyDecorators(
     Post(),
     JwtAccessTokenGuard(),
     ApiOkResponse({ description: '게시글 생성성공', type: undefined }),
+  );
+
+export const GetPostDetail = () =>
+  applyDecorators(
+    Get('detail'),
+    JwtAccessTokenGuard(),
+    ApiOkResponse({
+      description: '게시글 생성성공',
+      type: GetPostDetailResponseDto,
+    }),
   );

--- a/src/posts/posts.module.ts
+++ b/src/posts/posts.module.ts
@@ -2,12 +2,13 @@ import { Module } from '@nestjs/common';
 
 import { PrismaModule } from '@app/library/prisma';
 import { PostsRepository } from '@api/posts/posts.repository';
+import { PostsViewRepository } from '@api/posts/view/posts-view.repository';
 import { PostsService } from './posts.service';
 import { PostsController } from './posts.controller';
 
 @Module({
   imports: [PrismaModule],
-  providers: [PostsService, PostsRepository],
+  providers: [PostsService, PostsRepository, PostsViewRepository],
   controllers: [PostsController],
 })
 export class PostsModule {}

--- a/src/posts/posts.repository.ts
+++ b/src/posts/posts.repository.ts
@@ -1,7 +1,8 @@
 import { Injectable } from '@nestjs/common';
-import { posts, Prisma, PrismaClient } from '@prisma/client';
+import { posts } from '@prisma/client';
 
 import { now } from '@app/utils/';
+
 import { PrismaConnection } from '@app/library/prisma/type/prisma.type';
 
 @Injectable()

--- a/src/posts/posts.repository.ts
+++ b/src/posts/posts.repository.ts
@@ -1,7 +1,8 @@
 import { Injectable } from '@nestjs/common';
-import { posts, PrismaClient } from '@prisma/client';
+import { posts, Prisma, PrismaClient } from '@prisma/client';
 
 import { now } from '@app/utils/';
+import { PrismaConnection } from '@app/library/prisma/type/prisma.type';
 
 @Injectable()
 export class PostsRepository {
@@ -15,7 +16,7 @@ export class PostsRepository {
     markdownContent,
     isPrivate,
   }: {
-    prismaConnection: PrismaClient;
+    prismaConnection: PrismaConnection;
     userId: posts['usersID'];
     categoryId: posts['categoryID'];
     title: posts['title'];
@@ -36,6 +37,27 @@ export class PostsRepository {
         createdDay: now(), // NOTE: 인기글 조회를 위한 DATE 형식저장
         private: isPrivate ? 1 : 0,
       },
+    });
+  }
+
+  getDetailFindById(prismaConnection: PrismaConnection, postId: posts['id']) {
+    return prismaConnection.posts.findFirst({
+      where: {
+        id: postId,
+        deletedAt: null,
+        users: { deletedAt: null },
+      },
+      include: {
+        users: true,
+        category: true,
+      },
+    });
+  }
+
+  addViewCountById(prismaConnection: PrismaConnection, postId: posts['id']) {
+    return prismaConnection.posts.update({
+      data: { viewCounts: { increment: 1 } },
+      where: { id: postId },
     });
   }
 }

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -1,14 +1,20 @@
-import { Injectable } from '@nestjs/common';
-import { posts } from '@prisma/client';
+import {
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
+import { posts, postView } from '@prisma/client';
 
 import { PostsRepository } from '@api/posts/posts.repository';
 import { PrismaService } from '@app/library/prisma';
+import { PostsViewRepository } from '@api/posts/view/posts-view.repository';
 
 @Injectable()
 export class PostsService {
   constructor(
     private readonly prismaService: PrismaService,
     private readonly postsRepository: PostsRepository,
+    private readonly postsViewRepository: PostsViewRepository,
   ) {}
 
   async createPost({
@@ -38,5 +44,42 @@ export class PostsService {
       markdownContent,
       isPrivate,
     });
+  }
+
+  async getPostDetail(
+    postId: posts['id'],
+    userId: posts['usersID'] | null,
+    userIp: postView['userIP'],
+  ) {
+    try {
+      // NOTE: 조회수 카운트 및 히스토리 기록
+      await this.prismaService.$transaction(async (prisma) => {
+        const hasViewed =
+          await this.postsViewRepository.getOneByPostIdAndUserIp(
+            prisma,
+            postId,
+            userIp,
+          );
+        if (hasViewed) throw new Error('hasViewed');
+        await this.postsViewRepository.create(prisma, postId, userIp);
+        await this.postsRepository.addViewCountById(prisma, postId);
+      });
+    } catch (error) {
+      if (!(error instanceof Error)) throw new InternalServerErrorException();
+    }
+    // NOTE: 게시글 조회
+    const searchResult = await this.postsRepository.getDetailFindById(
+      this.prismaService,
+      postId,
+    );
+
+    if (!searchResult) throw new NotFoundException();
+
+    // NOTE: 비밀글일 경우 본인만 열람이 가능하다
+    if (searchResult.private === 1) {
+      if (searchResult.usersID !== userId) throw new NotFoundException();
+    }
+
+    return searchResult;
   }
 }

--- a/src/posts/view/posts-view.repository.ts
+++ b/src/posts/view/posts-view.repository.ts
@@ -1,7 +1,9 @@
-import { PrismaConnection } from '@app/library/prisma/type/prisma.type';
-import { now } from '@app/utils/';
 import { Injectable } from '@nestjs/common';
-import { postView, Prisma, PrismaClient } from '@prisma/client';
+import { postView } from '@prisma/client';
+
+import { now } from '@app/utils/';
+
+import { PrismaConnection } from '@app/library/prisma/type/prisma.type';
 
 @Injectable()
 export class PostsViewRepository {

--- a/src/posts/view/posts-view.repository.ts
+++ b/src/posts/view/posts-view.repository.ts
@@ -1,0 +1,27 @@
+import { PrismaConnection } from '@app/library/prisma/type/prisma.type';
+import { now } from '@app/utils/';
+import { Injectable } from '@nestjs/common';
+import { postView, Prisma, PrismaClient } from '@prisma/client';
+
+@Injectable()
+export class PostsViewRepository {
+  getOneByPostIdAndUserIp(
+    prismaConnection: PrismaConnection,
+    postId: postView['postsID'],
+    userIp: postView['userIP'],
+  ) {
+    return prismaConnection.postView.findFirst({
+      where: { postsID: postId, userIP: userIp },
+    });
+  }
+
+  create(
+    prismaConnection: PrismaConnection,
+    postId: postView['postsID'],
+    userIp: postView['userIP'],
+  ) {
+    return prismaConnection.postView.create({
+      data: { postsID: postId, userIP: userIp, viewedAt: now() },
+    });
+  }
+}

--- a/src/users/auth/users-auth.repository.ts
+++ b/src/users/auth/users-auth.repository.ts
@@ -1,11 +1,12 @@
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
-import { PrismaClient, usersAuth } from '@prisma/client';
+import { usersAuth } from '@prisma/client';
 
 import { now } from '@app/utils/';
 
 import { TokenPayload } from '@app/utils/token/types/token.type';
+import { PrismaConnection } from '@app/library/prisma/type/prisma.type';
 
 @Injectable()
 export class UsersAuthRepository {
@@ -22,7 +23,7 @@ export class UsersAuthRepository {
     userAgent,
     userIp,
   }: {
-    prismaConnection: PrismaClient;
+    prismaConnection: PrismaConnection;
     userId: usersAuth['userId'];
     refreshToken: usersAuth['refreshToken'];
     userAgent: usersAuth['userAgent'];
@@ -43,7 +44,7 @@ export class UsersAuthRepository {
     prismaConnection,
     refreshToken,
   }: {
-    prismaConnection: PrismaClient;
+    prismaConnection: PrismaConnection;
     refreshToken: usersAuth['refreshToken'];
   }) {
     return prismaConnection.usersAuth.findUnique({ where: { refreshToken } });
@@ -53,7 +54,7 @@ export class UsersAuthRepository {
     prismaConnection,
     refreshToken,
   }: {
-    prismaConnection: PrismaClient;
+    prismaConnection: PrismaConnection;
     refreshToken: usersAuth['refreshToken'];
   }) {
     return prismaConnection.usersAuth.deleteMany({ where: { refreshToken } });

--- a/src/users/users.repository.ts
+++ b/src/users/users.repository.ts
@@ -1,7 +1,9 @@
 import { Injectable } from '@nestjs/common';
-import { PrismaClient, OauthProvider, users } from '@prisma/client';
+import { OauthProvider, users } from '@prisma/client';
 
 import { now } from '@app/utils/';
+
+import { PrismaConnection } from '@app/library/prisma/type/prisma.type';
 
 @Injectable()
 export class UsersRepository {
@@ -10,7 +12,7 @@ export class UsersRepository {
     provider,
     providerServiceId,
   }: {
-    prismaConnection: PrismaClient;
+    prismaConnection: PrismaConnection;
     provider: OauthProvider;
     providerServiceId: users['providerServiceId'];
   }) {
@@ -33,7 +35,7 @@ export class UsersRepository {
     proFileImageURL,
     providerServiceId,
   }: {
-    prismaConnection: PrismaClient;
+    prismaConnection: PrismaConnection;
     userId: users['id'];
     providerServiceId: users['providerServiceId'];
     provider: OauthProvider;


### PR DESCRIPTION
# 구현 개요
- 게시글 상세 조회 기능

## 작업 사항
- ESLint 한 파일당 클래스 제한 해제
- Prisma 트랜잭션, 로깅 활성화
- 게시글 조회에 필요한 쿼리 작성
- 엔드포인트에 맞는 DTO생성

## 이슈 트래커 번호
resolve #33 

# Refactor
---
```
export type PrismaConnection = Omit<
  PrismaClient<
    Prisma.PrismaClientOptions,
    never,
    Prisma.RejectOnNotFound | Prisma.RejectPerOperation | undefined
  >,
  '$connect' | '$disconnect' | '$on' | '$transaction' | '$use'
>;
```

repository 메서드의 prismaClient는 기존 PrismaClient 타입을 사용했지만
트랜잭션 기능을 사용할경우 타입 호환이 불가능해 재사용성이 떨어지는 문제가 있었습니다
library/prisma/type에 트랜잭션 및 일반 prisma 클라이언트에도 호환되는 새로운 타입을 정의했습니다