### PR TITLE
Private 게시글 조회 문제, 유저 정보 조회 시 아이디

### DIFF
--- a/src/posts/dto/get-posts-detail.dto.ts
+++ b/src/posts/dto/get-posts-detail.dto.ts
@@ -1,12 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { category, posts, users } from '@prisma/client';
-import { Transform, Type } from 'class-transformer';
-import { IsEnum, IsInt, IsOptional, Max, Min } from 'class-validator';
 
 import {
   PostSearchDateScope,
   PostSearchSortScope,
 } from '@app/library/constants';
+import { Transform, Type } from 'class-transformer';
+import { IsEnum, IsInt, IsOptional, Max, Min } from 'class-validator';
 
 export class GetPostsRequestQueryDto {
   @IsEnum(PostSearchDateScope)
@@ -52,6 +52,8 @@ class GetPostsItem {
   view: posts['viewCounts'];
 
   like: posts['likes'];
+
+  private: posts['private'];
 
   createdAt: posts['createdAt'];
 

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -116,6 +116,7 @@ export class PostsController {
           view: item.viewCounts,
           like: item.likes,
           createdAt: item.createdAt,
+          private: item.private,
           user: {
             userId: item.users.id,
             username: item.users.userName,

--- a/src/posts/posts.repository.ts
+++ b/src/posts/posts.repository.ts
@@ -1,12 +1,12 @@
 import { Injectable } from '@nestjs/common';
 import { posts } from '@prisma/client';
 
-import { arrayOfLastDate, now } from '@app/library/date';
-
 import {
   PostSearchDateScope,
   PostSearchSortScope,
 } from '@app/library/constants';
+import { arrayOfLastDate, now } from '@app/library/date';
+
 import { PrismaConnection } from '@app/library/prisma/type/prisma.type';
 
 @Injectable()
@@ -136,7 +136,7 @@ export class PostsRepository {
       dateScope === PostSearchDateScope.All
         ? undefined
         : Number(PostSearchDateScope[`${dateScope}`]);
-
+    console.log(hasPrivatePosts);
     return prismaConnection.posts.findMany({
       include: {
         users: true,
@@ -145,7 +145,7 @@ export class PostsRepository {
       where: {
         ...(userId && { usersID: userId }),
         ...(categoryId && { categoryID: categoryId }),
-        ...(hasPrivatePosts ? { private: 1 } : { private: 0 }),
+        ...(!hasPrivatePosts && { private: 0 }),
         createdDay: {
           in: dayCount ? arrayOfLastDate(now(), dayCount) : undefined,
         },

--- a/src/users/dto/get-me.dto.ts
+++ b/src/users/dto/get-me.dto.ts
@@ -10,6 +10,8 @@ class GetMeUserSettingItem {
 }
 
 export class GetMeResponseDto {
+  userId: users['id'];
+
   name: users['userName'];
 
   @ApiProperty({ type: String, nullable: true })

--- a/src/users/setting/users-setting.service.ts
+++ b/src/users/setting/users-setting.service.ts
@@ -1,9 +1,9 @@
 import { Injectable, InternalServerErrorException } from '@nestjs/common';
 import { usersSetting } from '@prisma/client';
 
-import { PrismaService } from '@app/library/prisma';
 import { UsersSettingRepository } from '@api/users/setting/users-setting.repository';
 import { UsersRepository } from '@api/users/users.repository';
+import { PrismaService } from '@app/library/prisma';
 
 @Injectable()
 export class UsersSettingService {
@@ -52,6 +52,7 @@ export class UsersSettingService {
       if (!userProfile) throw new InternalServerErrorException();
 
       return {
+        userId: userProfile.id,
         name: userProfile.userName,
         avatar: userProfile.proFileImageURL,
         createdAt: userProfile.createdAt,


### PR DESCRIPTION
<!-- PR 제목 양식
   PR 제목이 깃 히스토리에 기록됨으로 반드시 어떤 요소를 개발 했는지 명시해 주세요
 -->

# 💫 PR

#### 이슈 트래커 번호
resolve #90 
<!-- resolve #{이슈번호} -->

---

## 1.작업 세부내역

<!-- 어떤 작업을 하셨나요? -->

- 유저 액세스 토큰 보유 시 private 게시글만 조회되는 문제를 해결했습니다
- 유저 상세정보 조회 시 아이디를 반환하지 않는 문제를 해결했습니다