### PR TITLE
댓글 생성 버그 수정 및 보완

### DIFF
--- a/src/comments/comments.service.ts
+++ b/src/comments/comments.service.ts
@@ -11,6 +11,7 @@ import { PrismaService } from '@app/library/prisma';
 
 import {
   commentNotFound,
+  replyToCommentNotFound,
   unauthorizedComment,
 } from '@api/comments/error/comments.error';
 import { postNotFound } from '@api/posts/error/posts.error';
@@ -40,6 +41,15 @@ export class CommentsService {
     );
 
     if (!hasPost) throw new NotFoundException(postNotFound);
+
+    if (replyTo) {
+      const hasComment = await this.commentsRepository.findOneByCommentId({
+        prismaConnection: this.prismaService,
+        commentId: replyTo,
+      });
+
+      if (!hasComment) throw new NotFoundException(replyToCommentNotFound);
+    }
 
     await this.commentsRepository.create({
       prismaConnection: this.prismaService,

--- a/src/comments/dto/create-comment.dto.ts
+++ b/src/comments/dto/create-comment.dto.ts
@@ -1,7 +1,8 @@
-import { IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
-import { Transform } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
 import { comments } from '@prisma/client';
+
+import { Transform } from 'class-transformer';
+import { IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
 
 export class CreateCommentsRequestBodyDto {
   @Transform(({ value }) => BigInt(value))
@@ -14,7 +15,7 @@ export class CreateCommentsRequestBodyDto {
   @MaxLength(300)
   content: comments['content'];
 
-  @Transform(({ value }) => BigInt(value))
+  @Transform(({ value }) => (value ? BigInt(value) : null))
   @IsOptional()
   @ApiProperty({ type: String, nullable: true })
   replyTo: comments['replyTo'];

--- a/src/comments/error/comments.error.ts
+++ b/src/comments/error/comments.error.ts
@@ -10,3 +10,8 @@ export const unauthorizedComment: ExceptionMessageInterface = {
   [COUNTRY.ko]: '수정 권한이 없는 댓글입니다.',
   [COUNTRY.en]: `This is a comment you don't have permission to edit.`,
 };
+
+export const replyToCommentNotFound: ExceptionMessageInterface = {
+  [COUNTRY.ko]: '존재하지 않는 댓글에는 답글을 달 수 없습니다.',
+  [COUNTRY.en]: 'You cannot reply to comments that do not exist.',
+};


### PR DESCRIPTION
# 💫 PR

<!-- resolve #{이슈번호} -->
resolve #87 
---

## 1.작업 세부내역

<!-- 어떤 작업을 하셨나요? -->

- 댓글 생성 시 replyTo가 null 값으로 들어올 경우 댓글 생성이 안되는 이슈 수정
- 존재하지 않는 댓글에 대해 답글을 달 수 없도록 수정

## 2.기타 변경 사항, 건의

<!-- 우리가 알고 있어야 할 추가 변경 사항, 리팩터링요소가 있나요? -->

## 3.Merge 이후 조치

<!-- 해당 PR이 Merge된 후 어떤 작업을 해야하거나 할 예정인가요?-->

- [ ] 서버 배포
